### PR TITLE
Allow filtering negative ratings from ials

### DIFF
--- a/examples/Warm-start and standard scenarios.ipynb
+++ b/examples/Warm-start and standard scenarios.ipynb
@@ -31,7 +31,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from polara.recommender.data import RecommenderData\n",
@@ -47,17 +49,17 @@
      "data": {
       "text/html": [
        "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -189,7 +191,8 @@
      "output_type": "stream",
      "text": [
       "Preparing data...\n",
-      "Done.\n"
+      "Done.\n",
+      "There are 996585 events in the training and 3624 events in the holdout.\n"
      ]
     }
    ],
@@ -236,7 +239,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from polara.recommender.models import SVDModel"
@@ -251,7 +256,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PureSVD training time: 0.12987111022293263s\n"
+      "PureSVD training time: 0.11708171694772318s\n"
      ]
     },
     {
@@ -282,7 +287,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# implicit library must be installed separately, follow instructions at https://github.com/benfred/implicit \n",
@@ -291,23 +298,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 15.0/15 [00:02<00:00,  5.88it/s]\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "iALS training time: 1.5761851485s\n"
+      "iALS training time: 2.5151202770066448s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Hits(true_positive=514, false_positive=116, true_negative=1160, false_negative=1834)"
+       "Hits(true_positive=623, false_positive=103, true_negative=1173, false_negative=1725)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,6 +329,13 @@
    "source": [
     "als = ImplicitALS(data_model) # create model\n",
     "als.switch_positive = 4 # same as for PureSVD, affects only evaluation\n",
+    "\n",
+    "als.train_switch_positive = 4  # filter out ratings < 4 from training set\n",
+    "\n",
+    "als.rank = 128\n",
+    "als.regularization = 32\n",
+    "als.weight_func = lambda x: x / 2  # set confidence to 0.5 the rating\n",
+    "\n",
     "als.build()\n",
     "als.evaluate()"
    ]
@@ -322,7 +343,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -335,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -344,7 +367,7 @@
        "2348"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -362,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -371,7 +394,7 @@
        "Relevance(precision=0.34864790286975716, recall=0.2008830022075055, fallout=0.05601545253863134, specifity=0.6227924944812362, miss_rate=0.7287527593818984)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -382,16 +405,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Relevance(precision=0.3536147902869757, recall=0.20516004415011035, fallout=0.06070640176600441, specifity=0.6181015452538631, miss_rate=0.7244757174392936)"
+       "Relevance(precision=0.402317880794702, recall=0.24655077262693156, fallout=0.05449779249448123, specifity=0.6243101545253864, miss_rate=0.6830849889624725)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -428,7 +451,8 @@
       "1 unique movieid's within 1 holdout interactions were filtered. Reason: not in the training data.\n",
       "1 of 1208 userid's were filtered out from holdout. Reason: not enough items.\n",
       "1 userid's were filtered out from testset. Reason: inconsistent with holdout.\n",
-      "Done.\n"
+      "Done.\n",
+      "There are 807458 events in the training and 3621 events in the holdout.\n"
      ]
     }
    ],
@@ -446,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -455,7 +479,7 @@
        "False"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -482,14 +506,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PureSVD training time: 0.10033848882716256s\n"
+      "PureSVD training time: 0.09450362698407844s\n"
      ]
     },
     {
@@ -498,7 +522,7 @@
        "Hits(true_positive=515, false_positive=111, true_negative=1164, false_negative=1831)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -525,24 +549,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "iALS model is not ready. Rebuilding.\n",
-      "iALS training time: 1.25310956069s\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "Hits(true_positive=509, false_positive=117, true_negative=1158, false_negative=1837)"
+       "Hits(true_positive=631, false_positive=129, true_negative=1146, false_negative=1715)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -569,7 +585,7 @@
        "2346"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,16 +603,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Relevance(precision=0.34907484120408727, recall=0.2020160176746755, fallout=0.056614194973764152, specifity=0.62192764429715541, miss_rate=0.7275614471140569)"
+       "Relevance(precision=0.34907484120408727, recall=0.2020160176746755, fallout=0.05661419497376415, specifity=0.6219276442971554, miss_rate=0.7275614471140569)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -607,16 +623,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Relevance(precision=0.34727975697321178, recall=0.19884009942004971, fallout=0.059375863021264838, specifity=0.61916597624965475, miss_rate=0.73073736536868272)"
+       "Relevance(precision=0.408036454018227, recall=0.2543496271748136, fallout=0.06407069870201601, specifity=0.6144711405689036, miss_rate=0.6752278376139187)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -646,7 +662,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -667,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   },
   "toc": {
    "nav_menu": {},

--- a/polara/recommender/external/implicit/ialswrapper.py
+++ b/polara/recommender/external/implicit/ialswrapper.py
@@ -20,6 +20,7 @@ class ImplicitALS(RecommenderModel):
         self.regularization = 0.01
         self.num_threads = 0
         self.num_epochs = 15
+        self.train_switch_positive = None
         self.method = 'iALS'
         self._model = None
 
@@ -51,6 +52,12 @@ class ImplicitALS(RecommenderModel):
 
         # prepare input matrix for learning the model
         matrix = self.get_training_matrix() # user_by_item sparse matrix
+
+        # filter out negative ratings if appropiate
+        if self.train_switch_positive:
+            matrix.data[matrix.data < self.train_switch_positive] = 0
+            matrix.eliminate_zeros()
+
         matrix.data = self.confidence(matrix.data, alpha=self.alpha, weight=self.weight_func)
 
         with Timer(self.method, verbose=self.verbose):


### PR DESCRIPTION
The implicit als model assumes that non-zeros passed in are positive ratings.
For datasets like movielens passing in 1 and 2 star reviews in the training set
causes these to be learned as positive preferences - which leads to poor results.

This adds a 'train_switch_positive' option to the ialswrapper, which when set
will remove ratings from the training set less than this value.

Applying this change to the warm-start example and the iALS model starts to perform
more competitively.